### PR TITLE
[이강혁] 4주차 정리

### DIFF
--- a/이강혁/3주차/5. 연관관계 매핑 기초.md
+++ b/이강혁/3주차/5. 연관관계 매핑 기초.md
@@ -1,0 +1,445 @@
+- 객체는 참조를 사용하여 관계를 맺지만 테이블은 외래 키를 사용하여 관계를 맺음
+- 객체 관계 매핑에서 이 패러다임의 차이가 어려움을 초래
+- 방향: 단방향, 양방향이 존재
+	- 회원 -> 팀, 팀->회원 이렇게 각각 참조하는 것은 단방향
+	- 서로가 서로를 참조하는 것을 양방향 관계라 함
+	- 방향은 객체 관계에서만 존재하고, 테이블은 언제나 양방향 관계임
+- 다중성: 일대일, 다대일, 일대다, 다대다가 존재
+	- 여러 회원은 한 팀에 속하므로 회원과 팀은 다대일 관계
+	- 반대로 한 팀에 여러 회원이 속하므로 팀과 회원은 일대다 관계
+- 연관관계의 주인: 객체를 양방향 연관관계로 만들면 연관관계의 주인을 정해야함
+
+---
+## 5.1 단방향 연관관계
+연관관계 중 다대일(N:1) 단방향 관계를 가장 먼저 이해해야함. 지금부터 회원과 팀의 관계를 통해 다대일 반방향 관계를 알아보겠음
+- 회원과 팀이 존재
+- 회원은 하나의 팀에만 소속 가능
+- 회원과 팀은 다대일 관계
+![[Pasted image 20240519182820.png]]
+#### 객체 연관관계
+- 회원 객체는 Member.team 필드로 팀 객체와 연관관계를 맺음
+- 회원 객체와 팀 객체는 단방향 관계임. 회원은 Member.team 필드를 통해 팀 객체를 알고 있지만 반대는 모름
+	- 따라서 team -> member로의 참조는 불가능
+
+#### 테이블 연관관계
+- 회원 테이블은 Team_ID 외래 키로 팀 테이블과 연관관계를 맺음
+- 회원 테이블과 팀 테이블은 양방향 관계. 
+	- 따라서 어떤 테이블을 이용하더라도 조인이 가능
+
+#### 객체 연관관계와 테이블 연관관계의 가장 큰 차이
+참조를 통한 연관관계는 언제나 단방향. 따라서 반대쪽에도 필드를 만들어 참조해야함
+- 정확하게 말하면 양방향은 아니고 서로 다른 단방향 관계를 2개 만드는 것
+- 테이블은 외래 키 하나로 항상 양방향 관계를 생성
+
+### 순수한 객체 연관관계
+순수하게 자바의 객체만을 사용한 연관관계를 살펴보자
+``` java
+public class Member {
+
+	private String id;
+	private String username;
+
+	private Team team;
+
+	public void setTeam(Team team) {
+		this.team = team;
+	}
+}
+```
+``` java
+public class Team {
+
+	private String id;
+	private String name;
+}
+```
+
+``` java
+psvm {
+
+	Member member1 = new Member("member1", "회원1");
+	Member member2 = new Member("member2", "회원2");
+	Team team1 = new Team("team1", "팀1");
+
+	member1.setTeam(team1);
+	member2.setTeam(team1);
+
+	Team findTeam = member1.getTeam();
+}
+```
+![[Pasted image 20240519184154.png]]
+- 회원 1과 회원 2는 팀 1에 소속되었음.
+- 이처럼 객체는 참조를 사용해 연관관계를 탐색할 수 있는데 이것을 객체 그래프 탐색이라고함
+
+### 테이블 연관관계
+이번에는 테이블의 회원과 팀의 관계를 살펴보자
+``` SQL
+create table member (
+	member_id varchar(255) not null,
+	team_id varchar(255),
+	username varchar(255),
+	primary key (member_id)
+)
+
+create table team (
+	team_id varchar(255) not null,
+	name varchar(255),
+	primary key (team_id)
+)
+
+alter table member add constraint fk_member_team
+	foreign key (team_id)
+	references team
+```
+
+``` SQL
+insert into team(team_id, name) values('team1', '팀1');
+
+insert into member(member_id, team_id, username)values('member1', 'team1', '회원1');
+insert into member(member_id, team_id, username)values('member2', 'team1', '회원2');
+```
+``` SQL
+select t.*
+from member m
+	join team t on m.team_id = t.team_id
+where m.member_id='member1'
+```
+- 이렇게 회원 1이 소속된 팀을 조회 가능
+- DB에서는 외래 키를 사용해 연관관계를 탐색할 수 있는데 이것을 조인이라함
+
+### 객체 관계 매핑
+이제 JPA를 사용해 둘을 매핑해보자
+![[Pasted image 20240519184802.png]]
+``` java
+@Entity
+public class Member {
+
+	@Id
+	@Column(name = "MEMBER_ID")
+	private String id;
+
+	private String username;
+
+	@ManyToOne
+	@JoinColumn(name="TEAM_ID")
+	private Team team;
+
+	public void setTeam(Team team){
+		this.team = team;
+	}
+}
+```
+- 회원과 팀은 다대일 관계이므로 다중성을 나타내는 어노테이션을 필수로 사용해야함
+	- 회원이 다. 팀이 1이기 때문에 위처럼 ManyToOne을 사용
+- 조인컬럼으로 외래 키를 매핑할 때 키 이름을 지정
+	- 해당 어노테이션을 생략해도 됨
+
+### @JoinColumn
+외래 키를 매핑할 때 사용
+![[Pasted image 20240519185211.png]]
+- 어노테이션을 생략하면 기본 전략을 사용
+- 기본 전략: 연관관계가 형성된 객체의 ID를 사용
+	- 필드명_컬럼명. (team_TEAM_ID)
+
+### @ManyToOne
+다대일 관계에서 사용
+![[Pasted image 20240519185330.png]]
+
+
+---
+## 5.2 연관관계 사용
+연관관계를 등록, 수정, 삭제, 조회하는 예제를 통해 어떻게 사용하는지 알아봄
+
+### 저장
+``` java
+public void testSave() {
+	
+	Team team1 = new Team("team1", "팀1");
+	em.persist(team1);
+
+	Member member1 = new Member("member1", "회원1");
+	member1.setTeam(team1);
+	em.persist(member1);
+	
+	Member member2 = new Member("member1", "회원1");
+	member2.setTeam(team1);
+	em.persist(member2);
+}
+```
+- 회원 엔티티는 팀 엔티티를 참조하고 저장. 
+- JPA는 참조한 팀의 식별자 (team.id)를 외래 키로 사용해 적절한 등록 쿼리를 생성
+- 아래는 생성된 쿼리문
+``` SQL
+insert into team(team_id, name) values('team1', '팀1');
+
+insert into member(member_id, team_id, username)values('member1', 'team1', '회원1');
+insert into member(member_id, team_id, username)values('member2', 'team1', '회원2');
+```
+- 외래 키를 적절하게 넣어서 엔티티를 만드는 것을 확인할 수 있음
+
+### 조회
+연관관계가 있는 엔티티를 조회하는 방법은 크게 2가지
+- 객체 그래프 탐색(객체 연관관계를 사용한 조회)
+- 객체지향 쿼리 사용(JPQL)
+
+#### 객체 그래프 탐색
+member.getTeam()을 사용해서 member와 연관된 team 엔티티를 조회할 수 있음
+``` java
+Member member = em.find(Member.class, "member1");
+Team team = member.getTeam();
+```
+- 이처럼 객체를 통해 연관된 엔티티를 조회하는 것을 객체 그래프 탐색이라 함
+- 더 자세한 내용은 8장에서
+
+#### 객체지향 쿼리 사용
+JPQL에서 어떻게 연관관계를 사용하는지 팀1에 소속된 모든 회원을 조회하는 예제로 살펴보자
+``` java
+private static void queryLogicJoin(EntityManager em) {
+
+	String jpql = "select m from Member m join m.team t where " + "t.name=:teamName";
+	List<Member> resultList = em.createQuery(jpql, Member.clas)
+	.setParameter("teamName", "팀1")
+	.getResultList();
+
+	for(Member member : resultList) {
+		sout(유저이름)
+	}
+}
+```
+- 회원이 팀과 관계를 지닌 필드인 m.team을 통해서 회원과 팀을 조인
+- 그리고 t.name을 검색조건으로 사용해 팀1에 속한 회원만 검색
+	- 참고로 :teamName과 간티 :로 시작하는 것은 파라미터를 바인딩 받는 문법임
+- 생성되는 SQL을 보자
+``` SQL
+select m.* from member member
+inner join
+	team team on member.team_id=team1_.id
+where
+	team1_.name='팀1'
+```
+- 생성된 SQL 쿼리보다 JPQL이 더 간결하게 작성 가능
+
+### 수정
+이번엔 어떻게 연관관계를 수정하는지 팀1 소속이던 회원을 팀2에 소속하도록 수정해보자
+``` java
+Team team2 = new Team("team2", "팀2");
+em.persist(team2);
+
+Member member = em.find(Member.class, "member1");
+member.setTeam(team2);
+```
+- 이때 실행되는 SQL은 다음과 같다
+``` SQL
+update member
+set 
+	team_id='team2', ...
+where
+	id='member1'
+```
+- 수정은 em.update() 같은 메소드가 없음
+- 단순히 엔티티의 값만 변경하면 변경 감지가 작동해 업데이트 해줌
+
+### 연관관계 제거
+회원1을 더이상 팀에 속하지 않게 변경해보자
+``` java
+Member member1 = em.find(Member.class, "member1");
+member1.setTeam(null); //연관관계 제거
+```
+- 이때 생성되는 SQL은 다음과 같다
+``` SQL
+update member
+set
+	team_id=null,...
+where
+	id='member1'
+```
+
+### 연관된 엔티티 삭제
+연관된 엔티티를 삭제하려면 기존에 있던 연관관계를 먼저 제거하고 삭제해야한다.
+- 그렇지 않으면 외래 키 제약조건으로 인해 DB에 오류 발생
+- 팀 1을 삭제하려면 회원과의 연관관계를 먼저 끊어야함
+``` java
+member1.setTeam(null);
+member2.setTeam(null);
+
+em.remove(team);
+```
+
+---
+
+## 5.3 양방향 연관관계
+지금까지 회원에서 팀으로만 접근하는 다대일 단방향 매핑을 알아보았다. 이번에는 반대 방향 관계를 추가해보자
+![[Pasted image 20240519192309.png]]
+- 회원과 팀은 다대일 관계. 팀과 회원은 일대다 관계
+- 일대다 관계는 여러 연관관계를 맺을 수 있으므로 컬렉션을 사용해야한다. Team.members를 List 컬렉션으로 추가
+	- 회원 -> 팀 (Member.team)
+	- 팀 -> 회원 (Team.members)
+- 테이블은 항상 양방향 이므로 따로 변경할 사항은 없다.
+
+### 양방향 연관관계 매핑
+``` java
+@Entity
+public class Member {
+
+	@Id
+	@Column(name = "MEMBER_ID")
+	private String id;
+
+	private String username;
+
+	@ManyToOne
+	@JoinColumn(name="TEAM_ID")
+	private Team team;
+
+	public void setTeam(Team team){
+		this.team = team;
+	}
+}
+```
+- 회원 엔티티는 기존과 동일
+``` java
+@Entity
+public class Team {
+
+	@Id
+	@Column(name="TEAM_ID")
+	private String id;
+	
+	private String name;
+
+	@OneToMany(mappedBy = "team")
+	private List<Member> members = new ArrayList<Member>();
+
+	//getter ~
+}
+```
+- 팀과 회원은 일대다 관계이기 때문에 컬렉션인 List를 추가하였고, @OneToMany 어노테이션을 사용했다
+- mappedBy 속성은 양방향 매핑일 때 사용하는데 반대쪽 매핑의 필드 이름을 값으로 주면 된다.
+	- 반대쪽 매핑이 Member.team 이므로 team을 값으로 주면됨
+
+### 일대다 컬렉션 조회
+팀에서 회원 컬렉션으로 객체 그래프 탐색을 사용해 조회한 회원들을 출력
+``` java
+public void biDirection(){
+
+	Team team = em.find(Team.class, "team1");
+	List<Member> members = team.getMembers();
+	// 팀->회원 객체 그래프 탐색
+}
+```
+- List로 불러오면 됨
+
+## 5.4 연관관계의 주인
+@OneToMany는 직관적으로 이해가 될 것. 하지만 mappedBy 속성은 왜 필요할까
+- 엄밀히 말해 객체는 양방향이 아닌 서로 다른 단방향 관계 2개를 만들어 사용하는 것임.
+- 테이블은 외래 키 하나로 두 테이블을 관리할 수 있으나 엔티티는 따로따로 관리하기 때문에 관리하는 포인트가 2곳으로 늘어남
+- 따라서 JPA 에서는 두 객체 연관관계 중 하나를 정해서 테이블의 외래 키를 관리해야 하는데 이를 연관관계의 주인이라함
+
+### 양방향 매핑의 규칙: 연관관계의 주인
+양방향 매핑시 두 연관관계 중 하나를 연관관계의 주인으로 정해야함
+- 연관관계의 주인만 DB 연관관계와 매핑되고 외래 키를 관리(등록, 수정, 삭제)할 수 있음
+- 반면에 주인이 아닌 쪽은 읽기만 할 수 있음
+- 어떤 연관관계를 주인으로 정할지는 mappedBy 속성을 사용하면 됨
+	- 주인은 mappedBy 속성을 사용하지 않음
+	- 주인이 아니면 mappedBy 속성을 사용해서 속성의 값으로 연관관계의 주인을 지정해야함
+
+#### 그렇다면 연관관계의 주인은 어떻게 정해야할까
+- 회원 엔티티의 관계를 주인으로 정하면 자신의 테이블에 있는 외래 키를 관리하면 됨
+- 팀 엔티티의 관계를 주인으로 정하면 물리적으로 다른 테이블에 있는 외래 키를 관리하기 때문에 비효율적임
+-> 
+### 연관관계의 주인은 외래 키가 있는 곳
+자신의 테이블에 외래 키가 있는 것이 관리하기 용이하기 때문에 회원 테이블의 Member.team이 주인이 됨
+- 주인이 아닌 Team.members에는 mappedBy="team" 속성을 사용해 주인이 아님을 설정
+- 여기서 "team"은 연관관계의 주인인 Member 엔티티의 team 필드를 말함
+
+---
+## 5.5 양방향 연관관계 저장
+``` java
+public void testSave(){
+
+	Team team1 = new Team("team1", "팀1");
+	em.persist(team1);
+
+	Member member1 = new Member("member1", "회원1");
+	member1.setTeam(team1);
+	em.persist(member1);
+	
+	Member member2 = new Member("member2", "회원2");
+	member2.setTeam(team1);
+	em.persist(member2);
+}
+```
+- 각 도메인 클래스에서 양방향 관계를 설정해도 저장하는 방식은 단뱡향 관계일 때와 동일
+- 양방향 연관관계는 주인이 외래 키를 관리. 따라서 주인이 아닌 방향은 값을 설정하지 않아도 DB에 외래 키 값이 정상 입력됨
+
+## 5.6 양방향 연관관계의 주의점
+가장 흔히 하는 실수는 연관관계의 주인에는 값을 입력하지 않고, 주인이 아닌 곳에만 값을 입력하는 것
+``` java
+Member member1 = new Member("member1", "회원1");
+em.persist(member1);
+
+Member member2 = new Member("member2", "회원2");
+em.persist(member2);
+
+Team team1 = new Team("team1", "팀1");
+team1.getMembers().add(member1);
+team1.getMembers().add(member2);
+
+em.persist(team1);
+```
+- 주인이 아닌 team에서 회원1, 2를 저장해도 외래 키의 값을 변경할 수 없기 때문에 값이 정상적으로 저장되지 않음 
+![[Pasted image 20240519200743.png]]
+
+### 순수한 객체까지 고려한 양방향 연관관계
+그렇다면 주인이 아닌 쪽에는 값을 저장하지 않아도 될까?
+-> 객체의 관점에서는 양쪽 방향에 모두 값을 입력해주는 것이 가장 안전
+- JPA 없는 순수 객체만 이용할 경우 한 방향에서만 데이터를 넣어주면 반대편에서는 저장되지 않음
+- 따라서 주인인 쪽에만 입력하지 말고 양방향 모두 값을 입력해주는 것이 베스트
+
+### 연관관계 편의 메소드
+다음처럼 member.setTeam과 team.getMembers().add()를 각각 호출하다 보면 둘 중 하나만 호출해서 양방향이 깨질 수 있음
+- 양방향 관계에서는 두 코드를 하나인 것처럼 사용하는 것이 안전
+``` java
+public class Member {
+	private Team team;
+
+	public void setTeam(Team team){
+		this.team = team;
+		team.getMembers().add(this);
+	}
+}
+```
+- 이렇게 setTeam() 메소드 하나로 양방향 관계를 모두 설정
+- 이런 메소드를 연관관계 편의 메소드라함
+
+### 연관관계 편의 메소드 작성 시 주의사항
+위 메소드에서 버그가 있다
+``` java
+member1.setTeam(teamA);
+member1.setTeam(teamB);
+Member findMember = teamA.getMember();
+```
+![[Pasted image 20240519202529.png]]
+- 연관관계를 변경하였지만, 기존 관계를 제거하지 않아 문제가 발생한다. 
+- 따라서 기존 관계가 있다면 이를 확인하고 제거한 후 변경하도록 수정해야한다.
+
+``` java
+public class Member {
+	private Team team;
+
+	public void setTeam(Team team){
+		if(this.team != null){
+			this.team.getMembers().remove(this);
+		}
+		this.team = team;
+		team.getMembers().add(this);
+	}
+}
+```
+- 서로 다른 단방향 연관관계 2개를 양방향인 것 처럼 보이게 하려면 이런 노력들이 많이 필요하다
+- 따라서 객체에서 양방향 연관관계를 사용하려면 로직을 견고하게 작성해야한다.
+
+## 정리
+- 단방향 매핑 만으로도 테이블과 객체의 연관관계 매핑은 완료
+- 양방향으로 만들면 반대 방향으로 객체 그래프 탐색 기능이 추가됨	
+- f양방향 연관관계를 매핑하려면 객체에서 양쪽 방향을 모두 관리해야함

--- a/이강혁/4주차/6. 다양한 연관관계 매핑.md
+++ b/이강혁/4주차/6. 다양한 연관관계 매핑.md
@@ -1,0 +1,443 @@
+연관관계를 매핑할 때 고려해야할 3가지
+1. 다중성
+	- 다대일: 단방향, 양방향
+	- 일대다: 단방향, 양방향
+	- 일대일: 주 테이블 단방향, 양방향
+	- 일대일: 대상 테이블 단방향, 양방향
+	- 다대다: 단방향, 양방향
+2. 단방향, 양방향
+3. 연관관계의 주인
+
+## 6.1 다대일
+다대일 관계의 반대 방향은 항상 일대다 관계고, 그 반대도 마찬가지
+- DB 테이블의 다대일 관계에서 외래 키는 항상 다쪽에 있음
+- 따라서 연관관계의 주인도 항상 다쪽으로 설정
+
+### 다대일 단방향
+<img width="659" alt="image" src="https://github.com/hyxklee/GitStudy/assets/77369759/25260769-07bf-4752-a5ca-0ccc58fb6059">
+``` java
+public class Member{
+	@Id
+	@GeneratedValue
+	@Column(name = "MEMBER_ID")
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "TEAM_ID")
+	private Team team;
+}
+```
+
+``` java
+public class Team{
+	@Id
+	@GeneratedValue
+	@Column(name = "TEAM_ID")
+	private Long id;
+}
+```
+- 회원은 팀을 알고 있지만, 팀은 회원을 모르는 단방향 연관관계
+- 즉 회원 엔티티에서만 관계를 맺고 있는 팀을 조회할 수 있음
+- 회원 클래스의 team 변수를 팀 클래스의 id(TEAM_ID)와 외래 키로 매핑함
+
+### 다대일 양방향
+<img width="645" alt="image" src="https://github.com/hyxklee/GitStudy/assets/77369759/5d1676ca-8ead-4eed-9a36-130d2ac45c05">
+- 단방향에서는 회원에서만 화살표가 나갔지만 양방향에서는 팀에서도 화살표가 나옴
+- 대신 연관관계의 주인이 회원이기 때문에 회원에서 나가는 건 실선, 팀에서 나가는 건 점선으로 표기
+
+``` java
+public class Member{
+	@Id
+	@GeneratedValue
+	@Column(name = "MEMBER_ID")
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "TEAM_ID")
+	private Team team;
+
+	public void setTeam(Team team){
+		this.team = team;
+	}
+
+	//무한루프에 빠지지 않도록 체크
+	if(!team.getMembers().contains(this)){
+		team.getMembers().add(this);
+	}
+}
+```
+
+``` java
+public class Team{
+	@Id
+	@GeneratedValue
+	@Column(name = "TEAM_ID")
+	private Long id;
+
+	@OneToMany(mappedBy = "team")
+	private List<Member> members = new ArrayList<Member>();
+
+	public void addMember(Member member){
+		this.members.add(member);
+		if(member.getTeam()!=this){ //무한루프에 빠지지 않도록 체크
+			member.setTeam(this);
+		}
+	}
+}
+```
+- 팀에서도 회원을 조회할 수 있게 관계를 하나 추가해주고, mappedBy로 설정해서 주인이 아님을 표시
+- 일대다 관계에서는 다쪽에 외래 키가 존재하기 때문에 다를 주인으로 설정 (일쪽에 외래 키가 있으면 다가 새로 생성될 때 마다 외래키 값이 너무 많이 늘어나 비효율적임)
+- 양방향 편의 메소드를 양쪽에서 작성하면 무한루프에 빠지므로 주의하고, 검사하는 로직도 넣어야한다
+
+---
+## 6.2 일대다
+일대다 관계는 다대일 관계의 반대 방향이다. 일대다 관계는 엔티티를 하나 이상 참조할 수 있으므로 자바 컬렉션인 Collection, List, Set, Map 중에 하나를 사용해야한다
+
+### 일대다 단방향
+하나의 팀은 여러 회원을 참조할 수 있다.
+<img width="673" alt="image" src="https://github.com/hyxklee/GitStudy/assets/77369759/6fe8fb2d-50f2-4c03-8d1d-a17fdc498fcd">
+- 외래 키는 회원쪽에 있기 때문에 팀에서 단방향을 맺어서 사용하려면 회원 테이블의 외래 키를 팀에서 관리하는 방식으로 사용
+
+``` java
+public class Team{
+	@Id
+	@GeneratedValue
+	@Column(name = "TEAM_ID")
+	private Long id;
+
+	@OneToMany
+	@JoinColumn(name = "TEAM_ID)
+	private List<Member> members = new ArrayList<Member>();
+
+	public void addMember(Member member){
+		this.members.add(member);
+		if(member.getTeam()!=this){ //무한루프에 빠지지 않도록 체크
+			member.setTeam(this);
+		}
+	}
+}
+```
+
+``` java
+public class Member{
+	@Id
+	@GeneratedValue
+	@Column(name = "MEMBER_ID")
+	private Long id;
+
+}
+```
+- 일대다 반방향 관계를 매핑할 때는 @JoinColumn을 명시해야함
+- 그렇지 않으면 JPA는 연결 테이블을 중간에 두고 연관관계를 관리하는 JoinTable 전략을 기본으로 적용함
+#### 단점
+- 매핑한 객체가 관리하는 외래 키가 다른 테이블에 있음
+- 본인 테이블의 외래 키를 처리하는 것보다 비효율적
+
+``` java
+public void testSave(){
+
+	Member member1 = new Member();
+	Member member2 = new Member();
+
+	Team team1 = new Team();
+	team1.getMembers().add(member1);
+	team1.getMembers().add(member2);
+
+	em.persist(member1); //insert
+	em.persist(member2); //insert
+	em.persist(team1);
+	//insert, update, update
+	
+	transaction.commit();
+}
+```
+- 회원 엔티티는 팀 엔티티를 모르기 때문에 팀 엔티티를 저장할 때 Team.members의 참조 값을 확인해 회원 테이블에 있는 외래 키를 업데이트함
+- -> 이렇게 쓰지 말고 다대일 양방향 매핑을 사용하자
+
+### 일대다 양방향
+일대다 양방향 매핑은 존재하지 않는다(다대일 양방향과 똑같음)
+- 양방향 매핑에서 @OneToMany는 주인이 될 수 없음. 외래 키가 없기 때문
+- 따라서 @ManyToOne이 주인이 됨 (여기엔 mappedBy 속성도 없음)
+- 어떻게 어떻게 양 쪽이 모두 외래 키를 관리하되, 다대일 쪽은 읽기만 가능하게 해서 일쪽에서 외래 키를 관리하게 할 수 있지만, 굳이 이렇게 하지 말 것
+
+---
+## 6.3 일대일
+일대일 관계는 양쪽이 서로 하나의 관계만 가짐
+- 회원은 하나의 사물함만 사용
+- 하나의 사물함도 한명에게만 할당
+#### 특징
+- 일대일 관계는 반대로 해도 일대일
+- 일대일 관계는 어떤 테이블에서도 외래키를 가질 수 있음
+- 주 테이블에 외래키
+	- 주 객체가 대상 객체를 참조하는 것처럼 사용
+	- 외래 키를 객체 참조와 비슷하게 사용할 수 있어 객체지향 개발자들이 선호
+	- 주 테이블만 확인해도 된다는 장점
+
+- 대상 테이블에 외래키
+	- 전통적인 DB 개발자들은 이 방법을 선호
+	- 테이블 관계를 일대다로 변경해도 구조를 그대로 유지가능(대상 테이블이 다쪽이 되는 경우가 많을테니)
+
+### 주 테이블에 외래키
+객체지향 개발자들이 선호하는 방법으로 JPA도 주 테이블에 외래 키가 있으면 좀 더 편리하게 매핑 가능
+
+#### 단방향
+<img width="652" alt="image" src="https://github.com/hyxklee/GitStudy/assets/77369759/8a8c9d21-c2b1-4cc0-9b61-c2b81e548331">
+- 회원이 주 테이블, 사물함이 대상 테이블
+
+``` java
+public class Member{
+	@Id
+	@GeneratedValue
+	@Column(name = "MEMBER_ID")
+	private Long id;
+
+	@OneToOne
+	@JoinColumn(name = "LOCKER_ID")
+	private Locker locker;
+}
+```
+
+``` java
+public class Locker{
+	@Id
+	@GeneratedValue
+	@Column(name = "LOCKER_ID")
+	private Long id;
+}
+```
+- 일대일 관계이므로 @OneToOne을 사용
+- 다대일 단방향과 유사
+
+#### 양방향
+<img width="649" alt="image" src="https://github.com/hyxklee/GitStudy/assets/77369759/b85ebf2a-7bef-4708-8f89-5ba003175e77">
+``` java
+public class Member{
+	@Id
+	@GeneratedValue
+	@Column(name = "MEMBER_ID")
+	private Long id;
+
+	@OneToOne
+	@JoinColumn(name = "LOCKER_ID")
+	private Locker locker;
+}
+```
+
+``` java
+public class Locker{
+	@Id
+	@GeneratedValue
+	@Column(name = "LOCKER_ID")
+	private Long id;
+
+	@OneToOne(mappedBy = "locker")
+	private Member member;
+}
+```
+- 양방향이므로 주인을 정하는데 해당 챕터는 주 테이블에 외래 키를 넣었으므로 주 테이블을 주인으로 설정
+- 따라서 사물함에 mappedBy 속성을 설정해 주인이 아니라고 설정
+
+### 대상 테이블에 외래키
+#### 단방향
+일대일 관계 중 대상 테이블에 외래 키가 있는 단방향 관계는 JPA에서 지원하지 않음
+- 이런 모양으로 매핑할 수 있는 방법도 없음
+- 따라서 단방향 관계를 사물함 -> 회원으로 수정하거나, 양방향 관계로 만들어 사물함을 주인으로 설정해야함
+<img width="671" alt="image" src="https://github.com/hyxklee/GitStudy/assets/77369759/ee118840-141a-4917-a48e-bad3e847bdd7">
+
+> [!NOTE] 질문
+> 아니 사물함->회원으로 가는 단방향을 맺으면 되는거 아님?
+> 꼭 회원->사물함으로 가는 단방향만 맺어야됨?
+
+#### 양방향
+<img width="639" alt="image" src="https://github.com/hyxklee/GitStudy/assets/77369759/40866082-1e47-4d3f-8d66-435c63b968a8">
+
+``` java
+public class Member{
+	@Id
+	@GeneratedValue
+	@Column(name = "MEMBER_ID")
+	private Long id;
+
+	@OneToOne(mappedBy="member")
+	private Locker locker;
+}
+```
+
+``` java
+public class Locker{
+	@Id
+	@GeneratedValue
+	@Column(name = "LOCKER_ID")
+	private Long id;
+
+	@OneToOne
+	@JoinColumn(name="MEMBER_ID")
+	private Member member;
+}
+```
+- 일대일 매핑에서 대상 테이블에 외래 키를 두고 싶으면 이렇게 양방향으로 매핑해야함
+- 사물함에 외래 키가 있기 때문에 주인으로 설정
+- 1:1 관계에서는 @JoinColumn으로 외래 키 설정
+
+---
+## 6.4 다대다
+관계형 DB는 정규화된 테이블 2개로 다대다 관계를 표현할 수 없음
+- 따라서 일대다, 다대일 관계로 풀어내는 중간 테이블을 생성해서 사용
+- 회원들 : 상품들 (다대다)
+<img width="648" alt="image" src="https://github.com/hyxklee/GitStudy/assets/77369759/42f4dcd9-1caa-4023-97ba-b20f1f2a1eb2">
+- 외래키만 가지는 연결 테이블을 통해 표현
+- 하지만 객체는 객체 2개로도 다대다 관계를 만들 수 있음
+	- 컬렉션끼리 참조하는 방식으로 
+
+``` java
+public class Member{
+	@Id
+	@GeneratedValue
+	@Column(name = "MEMBER_ID")
+	private Long id;
+
+	@ManyToMany
+	@JoinTable(name="MEMBER_PRODUCT", 
+				joinColumns = @JoinColumn(name="MEMBER_ID"), 
+				inverseJoinColumns = @JoinColumn(name = "PRODUCT_ID"))
+	private List<Product> products = new ArrayList<>(Product);
+}
+```
+
+``` java
+public class Product{
+	@Id
+	@GeneratedValue
+	@Column(name = "MEMBER_ID")
+	private Long id;
+}
+```
+- 회원 엔티티와 상품 엔티티를 @ManyToMany로 매핑
+- @JoinTable을 사용해 연결 테이블을 바로 매핑. 따라서 회원과 상품을 연결하는 회원_상품 엔티티 없이 매핑을 완료할 수 있음
+	- 객체 생성 없이 연결 테이블에 바로 매핑 가능
+#### @JoinTable 속성
+- @JoinTable.name: 연결 테이블 이름
+- @JoinTable.joinColumns: 현재 방향인 회원과 매핑할 조인 컬럼 정보를 지정. MEMBER_ID
+- @JoinTable.inversejoinColumns: 반대 방향인 상품과 매핑할 조인 컬럼 정보를 지정. PRODUCT_ID
+
+### 다대다 양방향
+``` java
+public class Product{
+	@Id
+	@GeneratedValue
+	@Column(name = "MEMBER_ID")
+	private Long id;
+
+	@ManyToMany(mappedBy="products")
+	private List<Member> members;
+}
+```
+- 역방향도 지정하고 mappedBy로 주인이 아님을 설정
+- 양방향 연관관계는 편의 메소드를 추가해서 관리하는 것이 편리
+
+``` java
+public class Member{
+	@Id
+	@GeneratedValue
+	@Column(name = "MEMBER_ID")
+	private Long id;
+
+	@ManyToMany
+	@JoinTable(name="MEMBER_PRODUCT", 
+				joinColumns = @JoinColumn(name="MEMBER_ID"), 
+				inverseJoinColumns = @JoinColumn(name = "PRODUCT_ID"))
+	private List<Product> products = new ArrayList<>(Product);
+
+	public void addProduct(Product product){
+		products.add(product);
+		products.getMembers().add(this);
+	}
+}
+```
+- member.addProduct(product);로 간단하게 양방향 연관관계 설정 가능
+
+### 다대다: 매핑의 한계와 극복, 연결 엔티티 사용
+@ManyToMany를 사용하면 연결 테이블을 자동으로 처리해주므로 간편하다
+허나 이 매핑을 실무에서 사용하기에는 여러 한계가 있다
+- 연결 테이블에 ID를 제외한 추가 컬럼이 들어가는 경우 결국 연결 테이블을 생성하고 일대다, 다대일 관계로 풀어야한다
+
+``` java
+@Entity
+@IdClass(MemberProductId.class)
+public class MemberProduct{
+
+	@Id
+	@ManyToOne
+	@JoinColumn(name = "MEMBER_ID")
+	private Member member; //MemberProductId.member와 연결
+
+	@Id
+	@ManyToOne
+	@JoinColumn(name = "PRODUCT_ID")
+	private Product product; //MemberProductId.product와 연결
+}
+```
+
+``` java
+public class MemberProductId implements Serializable{
+
+	private String member; //MemberProduct.member와 연결
+	private String product; //MemberProduct.product와 연결
+	
+}
+```
+- MemberProduct 엔티티를 보면 기본키와 외래키를 한 번에 매핑
+- @IdClass를 사용해 복합 기본키를 매핑
+
+#### 복합 기본키
+- 회원상품 엔티티는 기본키가 MEMBER_ID와  PRODUCT_ID로 이루어진 복합 기본키
+- JPA에서 복합키를 사용하려면 별도의 식별자 클래스(MemberProductId)를 생성 후 @IdClass를 사용해 식별자 클래스를 지정해 사용
+- Serializable을 구현해야함
+- equals와 hashCode 메소드를 필수로 구현해야함
+- 기본 생성자가 필수
+- 식별자 클래스는 public
+#### 식별 관계
+회원상품은 상품의 기본키를 받아 자신의 기본키로 사용. 이렇게 부모 테이블의 기본 키를 받아서 자신의 기본키+외래키로 사용하는 것을 DB 용어로 식별 관계라 함(Identifying Relationship) 
+- 회원상품 엔티티는 회원의 ID와 상품의 ID를 받아서 자신의 기본키로 사용함과 동시에 관계를 위한 외래키로 사용
+- 복합키를 사용해 객체를 매핑하는 것은 다소 복잡함
+
+### 다대다: 새로운 기본 키 사용
+추천하는 전략은 DB에서 자동으로 생성해주는 대리 키를 Long 값으로 사용하는 것
+- 이 방법의 장점은 간편하고 거의 영구히 쓸 수 있으며 비즈니스에 의존하지 않음
+- 또한 ORM 매핑시 복합 키를 만들지 않고 간단히 매핑할 수 있음
+![[Pasted image 20240526185016.png]]
+
+``` java
+public class Order{
+
+	@Id
+	@GeneratedValue
+	@Column(name = "ORDER_ID")
+	private Long Id;
+
+	@ManyToOne
+	@JoinColumn(name = "MEMBER_ID")
+	private Member member;
+
+	@ManyToOne
+	@JoinColumn(name = "PRODUCT_ID")
+	private Product product;
+}
+```
+- ORDER_ID를 만들어 기본키로 사용하고 회원과 상품 ID는 외래 키로만 사용
+
+``` java
+Long orderId = 1L;
+Order order = em.find(Order.class, orderId);
+
+Member member = order.getMember();
+Product product = order.getProduct();
+```
+- 식별자 클래스를 사용하지 않기 때문에 코드가 단순해짐. 
+- 연결 테이블의 기본키를 생성해 사용하는 것이 좋을듯
+
+### 다대다 연관관계 정리
+- 식별 관계: 받아온 식별자를 기본키+외래키로 사용
+- 비식별 관계: 받아온 식별자는 외래키로만 사용하고 새로운 식별자를 추가
+	- 1번 방법을 식별 관계라 하고, 2번 처럼 새로운 기본 키를 생성하는 방법을 비식별 관계라 함
+	- 일반적으로 비식별 관계를 추천


### PR DESCRIPTION
### 문제
1. 다대일 연관관계에서 외래 키는 항상 ()에 있으며 따라서 연관관계의 주인을 ()로 설정한다.
2. 일대다 관계에서 엔티티를 매핑할 때 사용하는 자바 컬렉션의 종류 3가지
3. 일대일 관계에서 외래 키를 주 테이블에 설정할 때 장단점 1개씩

### 질문
<img width="671" alt="ee118840-141a-4917-a48e-bad3e847bdd7" src="https://github.com/Leets-Official/Leets-JPA-Study/assets/77369759/f84e82ef-02d7-4f3b-a2e6-d055a6a033e4">
일대일 연관관계 중 대상 테이블에 외래 키를 둘 때 단방향 관계를 JPA에서 지원하지 않는다고 하는데 주 테이블 -> 대상 테이블로의 관계를 생성할 수 없다는 건 이해가 되는데, 외래 키가 다른 테이블에 있어 형성할 수 없다면 대상 테이블 -> 주 테이블로의 관계는 생성할 수 있는게 아닌가?? 아니면 그 반대의 관계는 사용하지 않는건가..?

### 느낀점
확실히 내용이 어려워졌고, 일대일이나 다대일, 다대다 관계 등 실제로 매핑할 일이 많은 관계들에 대한 방법을 전부 공부할 수 있어서 좋았다. 다음 장에서 더 심화된 내용을 학습하고 싶다.